### PR TITLE
Upgrade mermaid to v11.10.0+ to fix XSS vulnerabilities (CVE-2025-54880, CVE-2025-54881)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "markdown-it-sub": "^1.0.0",
         "markdown-it-sup": "^1.0.0",
         "md5": "^2.3.0",
-        "mermaid": "^11.9.0",
+        "mermaid": "^11.10.1",
         "minisearch": "^6.1.0",
         "mkdirp": "^3.0.1",
         "monaco-editor": "^0.43.0",
@@ -13449,9 +13449,9 @@
       }
     },
     "node_modules/mermaid": {
-      "version": "11.9.0",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.9.0.tgz",
-      "integrity": "sha512-YdPXn9slEwO0omQfQIsW6vS84weVQftIyyTGAZCwM//MGhPzL1+l6vO6bkf0wnP4tHigH1alZ5Ooy3HXI2gOag==",
+      "version": "11.10.1",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.10.1.tgz",
+      "integrity": "sha512-0PdeADVWURz7VMAX0+MiMcgfxFKY4aweSGsjgFihe3XlMKNqmai/cugMrqTd3WNHM93V+K+AZL6Wu6tB5HmxRw==",
       "license": "MIT",
       "dependencies": {
         "@braintree/sanitize-url": "^7.0.4",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "markdown-it-sub": "^1.0.0",
     "markdown-it-sup": "^1.0.0",
     "md5": "^2.3.0",
-    "mermaid": "^11.9.0",
+    "mermaid": "^11.10.1",
     "minisearch": "^6.1.0",
     "mkdirp": "^3.0.1",
     "monaco-editor": "^0.43.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6726,10 +6726,10 @@ merge2@^1.3.0, merge2@^1.4.1:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-mermaid@^11.9.0:
-  version "11.9.0"
-  resolved "https://registry.yarnpkg.com/mermaid/-/mermaid-11.9.0.tgz#fdc055d0f2a7f2afc13a78cb3e3c9b1374614e2e"
-  integrity sha512-YdPXn9slEwO0omQfQIsW6vS84weVQftIyyTGAZCwM//MGhPzL1+l6vO6bkf0wnP4tHigH1alZ5Ooy3HXI2gOag==
+mermaid@^11.10.1:
+  version "11.10.1"
+  resolved "https://registry.yarnpkg.com/mermaid/-/mermaid-11.10.1.tgz#c62ee121f2080291ba175ae880a16c0838070689"
+  integrity sha512-0PdeADVWURz7VMAX0+MiMcgfxFKY4aweSGsjgFihe3XlMKNqmai/cugMrqTd3WNHM93V+K+AZL6Wu6tB5HmxRw==
   dependencies:
     "@braintree/sanitize-url" "^7.0.4"
     "@iconify/utils" "^2.1.33"


### PR DESCRIPTION
This PR addresses the Cross-Site Scripting (XSS) vulnerabilities reported in `mermaid` prior to version 11.10.0.

The following change was made:

- Upgraded `mermaid` to `^11.10.0` via `yarn add` to ensure XSS patches are applied.

Relevant Security Alerts:  
- https://github.com/yasuhirokudo/crossnote/security/dependabot/35
- https://github.com/yasuhirokudo/crossnote/security/dependabot/36
- https://github.com/yasuhirokudo/crossnote/security/dependabot/39
- https://github.com/yasuhirokudo/crossnote/security/dependabot/40

This mitigates the vulnerabilities identified as **CVE-2025-54880** and **CVE-2025-54881**, and helps ensure safe rendering of sequence and architecture diagrams.
