### PR TITLE
Upgrade axios to fix CVE-2025-58754

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@ungap/structured-clone": "^1.2.0",
         "@viz-js/viz": "^3.1.0",
         "async-mutex": "^0.4.0",
-        "axios": "^1.11.0",
+        "axios": "^1.12.2",
         "bit-field": "^1.9.0",
         "case-anything": "^2.1.13",
         "cheerio": "^1.0.0-rc.12",
@@ -6095,9 +6095,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@ungap/structured-clone": "^1.2.0",
     "@viz-js/viz": "^3.1.0",
     "async-mutex": "^0.4.0",
-    "axios": "^1.11.0",
+    "axios": "^1.12.2",
     "bit-field": "^1.9.0",
     "case-anything": "^2.1.13",
     "cheerio": "^1.0.0-rc.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2859,10 +2859,10 @@ available-typed-arrays@^1.0.6, available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-axios@^1.11.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.11.0.tgz#c2ec219e35e414c025b2095e8b8280278478fdb6"
-  integrity sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==
+axios@^1.12.2:
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.12.2.tgz#6c307390136cf7a2278d09cec63b136dfc6e6da7"
+  integrity sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==
   dependencies:
     follow-redirects "^1.15.6"
     form-data "^4.0.4"


### PR DESCRIPTION
This PR addresses the Cross-Site Scripting (XSS) vulnerability reported in `axios` prior to version 1.7.3.

The following change was made:

- Upgraded `axios` to `^1.12.2` via `yarn add` to ensure the XSS fix is applied.

Relevant Security Alerts:  
- https://github.com/yasuhirokudo/crossnote/security/dependabot/42  
- https://github.com/yasuhirokudo/crossnote/security/dependabot/43

This mitigates the vulnerability identified as **CVE-2025-58754**, which affects URL sanitization and could lead to improper rendering or execution in certain edge cases.
