### PR TITLE
Update tar-fs to 3.1.1 to address CVE-2025-59343

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16366,9 +16366,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.0.tgz",
-      "integrity": "sha512-5Mty5y/sOF1YWj1J6GiBodjlDc05CUR8PKXrsnFAiSG0xA+GHeWLovaZPYUDXkH/1iKRf2+M5+OrRgzC7O9b7w==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
+      "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
       "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8467,9 +8467,9 @@ tailwindcss@^3.1, tailwindcss@^3.2.4, tailwindcss@^3.3.3:
     sucrase "^3.32.0"
 
 tar-fs@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-3.1.0.tgz#4675e2254d81410e609d91581a762608de999d25"
-  integrity sha512-5Mty5y/sOF1YWj1J6GiBodjlDc05CUR8PKXrsnFAiSG0xA+GHeWLovaZPYUDXkH/1iKRf2+M5+OrRgzC7O9b7w==
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-3.1.1.tgz#4f164e59fb60f103d472360731e8c6bb4a7fe9ef"
+  integrity sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==
   dependencies:
     pump "^3.0.0"
     tar-stream "^3.1.5"


### PR DESCRIPTION
This PR updates the `tar-fs` package to version `3.1.1` to address the security vulnerability **CVE-2025-59343**.

The following change was made:

Relevant Security Alerts:  
- https://github.com/yasuhirokudo/crossnote/security/dependabot/44  
- https://github.com/yasuhirokudo/crossnote/security/dependabot/45  

This update mitigates a potential Arbitrary File Write vulnerability during tar extraction, ensuring safer dependency resolution during install operations.
